### PR TITLE
Build and upload AppImage for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: xenial
+
+before_install:
+  - sudo add-apt-repository ppa:beineri/opt-qt591-xenial -y
+  - sudo apt-get update -qq
+
+install:
+  - sudo apt-get -y install qt59base qt59tools qt59websockets libgl1-mesa-dev
+  - source /opt/qt*/bin/qt*-env.sh
+  - export CXX="g++-5"
+  - export CC="gcc-5"
+  
+script:
+  - git clone https://github.com/emqtt/qmqtt
+  - cd qmqtt/
+  - qmake CONFIG+=release
+  - make CXX=$CXX -j$(nproc)
+  - export LD_LIBRARY_PATH=
+  - sudo make -j$(nproc) install
+  - sudo mv /opt/qt*/include/qmqtt . ; sudo cp -r ./qmqtt/* /opt/qt*/include/ # FIXME; it is not found there
+  - cd ..
+  - qmake CONFIG+=release PREFIX=/usr
+  - make -j$(nproc)
+  # make INSTALL_ROOT=appdir -j$(nproc) install ; find appdir/ # FIXME
+  - mkdir -p appdir/usr/bin ; cp ./qmqtt-client ./appdir/usr/bin/
+  - mkdir -p appdir/usr/share/applications ; cp qmqtt-client.desktop appdir/usr/share/applications/ # FIXME
+  - mkdir -p appdir/usr/share/icons/hicolor/scalable/apps/ ; touch appdir/usr/share/icons/hicolor/scalable/apps/qmqtt-client.svg
+  - wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+  - chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+  - unset LD_LIBRARY_PATH # needed because linuxdeployqt uses the wrong Qt otherwise
+  - ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -appimage
+
+after_success:
+  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  - bash upload.sh QMQTT*.AppImage*
+  
+branches:
+  except:
+    - # Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)/

--- a/qmqtt-client.desktop
+++ b/qmqtt-client.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=QMQTT Client
+Comment=MQTT Client GUI Written with Qt 
+Icon=qmqtt-client
+Type=Application
+Categories=Engineering;Development;
+Exec=qmqtt-client


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to your GitHub Releases page.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions
- Can be listed in the [AppImageHub](https://appimage.github.io/) central directory of available AppImages
- Can double as a self-extracting compressed archive with the `--appimage-extract` parameter
- No repositories needed. Suitable/optimized for air-gapped (offline) machines
- Decentralized

[Here is an overview](https://appimage.github.io/apps) of projects that are already distributing upstream-provided, official AppImages.

__PLEASE NOTE:__ For this to work, you need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.